### PR TITLE
Changed default property of the createdAt field to a function

### DIFF
--- a/models/Thought.js
+++ b/models/Thought.js
@@ -11,7 +11,7 @@ const thoughtSchema = new mongoose.Schema(
     },
     createdAt: {
       type: Date,
-      default: new Date(),
+      default: () => new Date(),
     },
     username: {
       type: String,


### PR DESCRIPTION
When the default property is not set to a function, it will set the date to the moment when the schema was compiled, and that same date will be used as the default value for all new documents created using this schema.

By making it a function, it will allow each document to have its own separate date