### PR TITLE
Added reaction schema to the mongoose DB

### DIFF
--- a/models/Reaction.js
+++ b/models/Reaction.js
@@ -1,0 +1,29 @@
+const { Schema, Types } = require("mongoose");
+
+// Schema for Reaction Document
+const reactionSchema = new mongoose.Schema({
+  reactionId: {
+    type: Schema.Types.ObjectId,
+    default: () => new Types.ObjectId(),
+  },
+  reactionBody: {
+    type: String,
+    required: true,
+    maxlength: 280,
+  },
+  username: {
+    type: String,
+    required: true,
+  },
+  createdAt: {
+    type: Date,
+    default: new Date(),
+  },
+});
+
+// Adds a virtual field with a formatted version of the createdAt field that is easier to read
+reactionSchema.virtual("formattedCreatedAt").get(function () {
+  return `${this.createdAt.getMonth()}/${this.createdAt.getDay()}/${this.createdAt.getFullYear()}`;
+});
+
+module.exports = reactionSchema;


### PR DESCRIPTION
The reaction Schema follows the following guidelines:

**Reaction (SCHEMA ONLY)**

**reactionId**

- Use Mongoose's ObjectId data type
- Default value is set to a new ObjectId

**reactionBody**

- String
- Required
- 280 character maximum

**username**

- String
- Required

**createdAt**

- Date
- Set default value to the current timestamp
- Use a getter method to format the timestamp on query

**Schema Settings**

- This will not be a model, but rather will be used as the reaction field's subdocument schema in the Thought model.