### PR TITLE
Fixed Thought Schema and created api controllers that conduct CRUD operations to Thought model

### DIFF
--- a/controllers/thoughtController.js
+++ b/controllers/thoughtController.js
@@ -1,0 +1,149 @@
+const { User, Thought } = require("../models");
+
+module.exports = {
+  // Get all thoughts
+  async getAllThoughts(req, res) {
+    try {
+      const thoughts = await Thought.find({});
+      res.json(thoughts);
+    } catch (err) {
+      res.status(500).json(err);
+    }
+  },
+  // GET a single thought by its _id
+  async getThought(req, res) {
+    try {
+      const thought = await Thought.findById(req.params.thoughtId).select(
+        "-__v"
+      );
+
+      if (!thought) {
+        return res.status(404).json({ message: "No thought with that ID" });
+      }
+
+      res.json(thought);
+    } catch (err) {
+      res.status(500).json(err);
+    }
+  },
+  /* POST/create a new thought
+    example data:
+        {
+            "thoughtText": "Here's a cool thought...",
+            "username": "lernantino",
+            "userId": "5edff358a0fcb779aa7b118b"
+        }
+    */
+  async createThought(req, res) {
+    try {
+      const newThought = await Thought.create(req.body);
+
+      const updatedUser = await User.findOneAndUpdate(
+        {
+          _id: req.body.userId,
+        },
+        {
+          // adds the newly created thought's id to the corresponding user's thoughts field array
+          $addToSet: { thoughts: newThought._id },
+        },
+        { runValidators: true, new: true }
+      );
+
+      if (!updatedUser) {
+        return res.status(404).json({ message: "No user with that ID" });
+      }
+
+      res.json(newThought);
+    } catch (err) {
+      res.status(500).json(err);
+    }
+  },
+  // PUT to update a thought by its _id
+  async updateThought(req, res) {
+    try {
+      const updatedThought = await Thought.findByIdAndUpdate(
+        req.params.thoughtId,
+        {
+          // only changes the fields placed in the request body
+          $set: req.body,
+        },
+        { runValidators: true, new: true }
+      );
+
+      if (!updatedThought) {
+        return res.status(404).json({ message: "No thought with that ID" });
+      }
+
+      res.json(updatedThought);
+    } catch (err) {
+      res.status(500).json(err);
+    }
+  },
+  // DELETE to remove thought by its _id
+  async deleteThought(req, res) {
+    try {
+      const deletedThought = await Thought.findByIdAndDelete(
+        req.params.thoughtId
+      );
+
+      if (!deletedThought) {
+        return res.status(404).json({ message: "No thought with that ID" });
+      }
+
+      res.json(deletedThought);
+    } catch (err) {
+      res.status(500).json(err);
+    }
+  },
+  /*POST to create a reaction stored in a single thought's reactions array field
+  example data:
+        {
+            "reactionId": "8eddr358a0fab779aa7b118b",
+            "reactionBody": "HAHA",
+            "username": "abed605"
+        }
+*/
+  async createReaction(req, res) {
+    try {
+      const updatedThought = await Thought.findByIdAndUpdate(
+        req.params.thoughtId,
+        {
+          // adds an entry to the reactions array containing the entire request body
+          $addToSet: { reactions: req.body },
+        },
+        { runValidators: true, new: true }
+      );
+
+      if (!updatedThought) {
+        return res
+          .status(404)
+          .json({ message: "No thought created by a user with that username" });
+      }
+
+      res.json(updatedThought);
+    } catch (err) {
+      res.status(500).json(err);
+    }
+  },
+  // DELETE to pull and remove a reaction by the reaction's reactionId value
+  async deleteReaction(req, res) {
+    try {
+      const updatedThought = await Thought.findByIdAndUpdate(
+        req.params.thoughtId,
+        {
+          // finds and removes entries in the Thought's reactions array by looking for entires with a reactionId of that in the req parameters
+          $pull: { reactions: { reactionId: req.params.reactionId } },
+        },
+        { runValidators: true, new: true }
+      );
+
+      if (!updatedThought) {
+        return res.status(404).json({ message: "No thought  with that ID" });
+      }
+
+      res.json(updatedThought);
+    } catch (err) {
+      res.status(500).json(err);
+    }
+  },
+};

--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -48,6 +48,7 @@ module.exports = {
       const updatedUser = await User.findByIdAndUpdate(
         req.params.userId,
         {
+          // only changes the fields placed in the request body
           $set: req.body,
         },
         { runValidators: true, new: true }
@@ -84,6 +85,7 @@ module.exports = {
       const user = await User.findByIdAndUpdate(
         req.params.userId,
         {
+          // adds the friends id to the corresponding user's friends field array
           $addToSet: { friends: req.params.friendId },
         },
         { runValidators: true, new: true }
@@ -104,6 +106,7 @@ module.exports = {
       const user = await User.findByIdAndUpdate(
         req.params.userId,
         {
+          // finds and removes entries in the Users's friends array by looking for entires with a friendId of that in the req parameters
           $pull: { friends: req.params.friendId },
         },
         { runValidators: true, new: true }

--- a/models/Reaction.js
+++ b/models/Reaction.js
@@ -17,7 +17,7 @@ const reactionSchema = new mongoose.Schema({
   },
   createdAt: {
     type: Date,
-    default: new Date(),
+    default: () => new Date(),
   },
 });
 

--- a/models/Thought.js
+++ b/models/Thought.js
@@ -1,4 +1,5 @@
 const { Schema, Types } = require("mongoose");
+const reaction = require("./Reaction");
 
 // Schema to create Thought model
 const thoughtSchema = new mongoose.Schema(
@@ -17,12 +18,7 @@ const thoughtSchema = new mongoose.Schema(
       type: String,
       required: true,
     },
-    reactions: [
-      {
-        type: Schema.Types.ObjectId,
-        ref: "reaction",
-      },
-    ],
+    reactions: [reaction],
   },
   {
     toJSON: {


### PR DESCRIPTION
In the Thought Schema, we were previously referencing the reaction model for the thought's reactions property. However, the reactions are only a schema and not a model. The new changes allow referencing the entire reaction (the array will contain subdocuments following the reactions schema) instead of just an array of id references.

The requirements of the controller routes are as follows:

**/api/thoughts**

- GET to get all thoughts
- GET to get a single thought by its _id
- POST to create a new thought (don't forget to push the created thought's _id to the associated user's thoughts array field)
- PUT to update a thought by its _id
- DELETE to remove a thought by its _id

**/api/thoughts/:thoughtId/reactions**

- POST to create a reaction stored in a single thought's reactions array field
- DELETE to pull and remove a reaction by the reaction's reactionId value